### PR TITLE
Fix typo: rename confirmUserDeletion to confirmingUserDeletion

### DIFF
--- a/stubs/inertia-svelte-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Pages/Profile/Partials/DeleteUserForm.svelte
@@ -27,7 +27,7 @@
             onError: () => passwordInput?.focus(),
             onFinish: () => $form.reset()
         });
-        confirmUserDeletion = false;
+        confirmingUserDeletion = false;
     }
 
     function closeModal() {

--- a/stubs/inertia-svelte/resources/js/Pages/Profile/Partials/DeleteUserForm.svelte
+++ b/stubs/inertia-svelte/resources/js/Pages/Profile/Partials/DeleteUserForm.svelte
@@ -29,7 +29,7 @@
             onError: () => passwordInput?.focus(),
             onFinish: () => $form.reset(),
         });
-        confirmUserDeletion = false;
+        confirmingUserDeletion = false;
     }
 
     function closeModal() {


### PR DESCRIPTION
- Ref: senkulabs/breeze-lite/pull/18

Fix lint errors bellow:

```bash
% npm run lint

> lint
> eslint resources/js --fix

/path/to/resources/js/Pages/Profile/Partials/DeleteUserForm.svelte
  20:14  error  `confirmUserDeletion` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates
https://svelte.dev/e/non_reactive_update(non_reactive_update)  svelte/valid-compile
  31:9   error  'confirmUserDeletion' is a function     no-func-assign
```