### PR TITLE
Fix linting errors for TypeScript-enabled setups

### DIFF
--- a/stubs/inertia-svelte-ts/resources/js/Components/DropdownLink.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Components/DropdownLink.svelte
@@ -4,7 +4,6 @@
 
     let {
         children,
-        href,
         ...attrs
     }: {
         children: Snippet;
@@ -13,7 +12,6 @@
 
 <Link
     {...attrs}
-    {href}
     class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
 >
     {@render children()}

--- a/stubs/inertia-svelte-ts/resources/js/Components/DropdownLink.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Components/DropdownLink.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
-    import type { Snippet } from 'svelte';
+    import type { ComponentProps, Snippet } from 'svelte';
     import { Link } from '@inertiajs/svelte';
-    import type { Method } from '@inertiajs/core';
 
     let {
         children,
         href,
-        method,
-        as,
         ...attrs
     }: {
         children: Snippet;
-        href: string;
-        method?: Method;
-        as?: keyof HTMLElementTagNameMap;
-    } = $props();
+    } & ComponentProps<Link> = $props();
 </script>
 
 <Link

--- a/stubs/inertia-svelte-ts/resources/js/Components/NavLink.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Components/NavLink.svelte
@@ -1,22 +1,16 @@
 <script lang="ts">
-    import type { Snippet } from 'svelte';
+    import type { ComponentProps, Snippet } from 'svelte';
     import { Link } from '@inertiajs/svelte';
-    import type { Method } from '@inertiajs/core';
 
     let {
         active = false,
         children,
         href,
-        method,
-        as,
         ...attrs
     }: {
         active?: boolean;
         children: Snippet;
-        href: string;
-        method?: Method;
-        as?: keyof HTMLElementTagNameMap;
-    } = $props();
+    } & ComponentProps<Link> = $props();
 </script>
 
 <Link

--- a/stubs/inertia-svelte-ts/resources/js/Components/NavLink.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Components/NavLink.svelte
@@ -5,7 +5,6 @@
     let {
         active = false,
         children,
-        href,
         ...attrs
     }: {
         active?: boolean;
@@ -15,7 +14,6 @@
 
 <Link
     {...attrs}
-    {href}
     class={active
         ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 dark:border-indigo-600 text-sm font-medium leading-5 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
         : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-700 focus:outline-none focus:text-gray-700 dark:focus:text-gray-300 focus:border-gray-300 dark:focus:border-gray-700 transition duration-150 ease-in-out'}

--- a/stubs/inertia-svelte-ts/resources/js/Components/ResponsiveNavLink.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Components/ResponsiveNavLink.svelte
@@ -5,7 +5,6 @@
     let {
         active = false,
         children,
-        href,
         ...attrs
     }: {
         active?: boolean;
@@ -15,7 +14,6 @@
 
 <Link
     {...attrs}
-    {href}
     class={`
         block w-full border-l-4 py-2 pe-4 ps-3 text-start text-base font-medium transition duration-150 ease-in-out
         ${

--- a/stubs/inertia-svelte-ts/resources/js/Components/ResponsiveNavLink.svelte
+++ b/stubs/inertia-svelte-ts/resources/js/Components/ResponsiveNavLink.svelte
@@ -1,22 +1,16 @@
 <script lang="ts">
-    import type { Snippet } from 'svelte';
+    import type { ComponentProps, Snippet } from 'svelte';
     import { Link } from '@inertiajs/svelte';
-    import type { Method } from '@inertiajs/core';
 
     let {
         active = false,
         children,
         href,
-        method,
-        as,
         ...attrs
     }: {
         active?: boolean;
         children: Snippet;
-        href: string;
-        method?: Method;
-        as?: keyof HTMLElementTagNameMap;
-    } = $props();
+    } & ComponentProps<Link> = $props();
 </script>
 
 <Link


### PR DESCRIPTION
**Summary:**
First, I’d like to express my gratitude for this incredible project and the work being done here—it’s been inspiring to explore and use the Laravel + Inertia + Svelte stack. This pull request addresses an issue I encountered when running the linter in a TypeScript-enabled setup.

**Problem:**
When initializing the project with TypeScript mode and running `npm run lint`, the following errors are produced:

```bash
% npm run lint
> eslint resources/js --fix

/path/to/resources/js/Components/DropdownLink.svelte
   9:9  error  'method' is assigned a value but never used  @typescript-eslint/no-unused-vars
  10:9  error  'as' is assigned a value but never used      @typescript-eslint/no-unused-vars
...
```

This occurs because some variables are declared but not explicitly used or initialized, which leads to linting errors in TypeScript environments.

**Solution:**
I made the following adjustments to resolve the issue:

```ts
// Before:
import type { Snippet } from "svelte";
import { Link } from "@inertiajs/svelte";
import type { Method } from "@inertiajs/core";

let {
  children,
  href,
  method,
  as,
  ...attrs
}: {
  children: Snippet;
  href: string;
  method?: Method;
  as?: keyof HTMLElementTagNameMap;
} = $props();

// After:
import type { ComponentProps, Snippet } from "svelte"; // Use ComponentProps to ensure all props are typed
import { Link } from "@inertiajs/svelte";

let {
  children,
  ...attrs
}: {
  children: Snippet;
} & ComponentProps<Link> = $props();
```

![スクリーンショット 2025-01-26 11 37 18](https://github.com/user-attachments/assets/85daac41-cfa9-4ed7-a5db-6c95d2a91a3b)

By using `ComponentProps<Link>` instead of explicitly typing all props, we ensure the prop types are consistent with the library’s definition. This approach reduces the likelihood of type mismatches in future updates, as it automatically inherits any changes made to the `Link` component’s props in the library. Additionally, it simplifies the code by removing the need to manually define and maintain types like `method` and `as`.

These changes prevent the linter from throwing errors when running `npm run lint` in TypeScript mode, ensuring a smoother developer experience right from setup.

**Impact:**
This fix improves the out-of-the-box developer experience for those using TypeScript, enabling them to focus on building with the stack rather than troubleshooting linting issues.

**Feedback:**
As someone deeply inspired by this project, I’d love to contribute and help refine it in whatever small way I can. If there’s anything I can improve in this pull request or any adjustments you’d like to see, I’m happy to collaborate and make changes.

Thank you again for the opportunity to contribute—your work has truly made a difference in the development experience for many! Looking forward to hearing your thoughts.
