### PR TITLE
fix: Ensure Inertia.js version consistency between frontend and backend

### DIFF
--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -18,7 +18,7 @@ trait InstallsInertiaStacks
     protected function installInertiaSvelteStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^1.0', 'laravel/sanctum:^4.0', 'tightenco/ziggy:^2.0'])) {
+        if (! $this->requireComposerPackages(['inertiajs/inertia-laravel:^2.0', 'laravel/sanctum:^4.0', 'tightenco/ziggy:^2.0'])) {
             return 1;
         }
 
@@ -66,7 +66,7 @@ trait InstallsInertiaStacks
                     ] + $packages;
                 });
 
-                
+
                 $this->updateNodeScripts(function ($scripts) {
                     return $scripts + [
                         'check' => 'svelte-check --tsconfig ./tsconfig.json',


### PR DESCRIPTION
The Inertia.js frontend package was already updated to version 2, but the backend package (inertiajs/inertia-laravel) remained at version 1 (https://github.com/senkulabs/breeze-lite/commit/3a3c3b81b17b1c7ee1c903745ed709029b90dadd) . This PR updates inertiajs/inertia-laravel to ^2.0 to ensure version consistency between the frontend and backend.

### Changes:

- Update inertiajs/inertia-laravel from ^1.0 to ^2.0
- Fix version mismatch between frontend and backend dependencies

This should prevent potential compatibility issues when using Inertia.js in both environments.