### PR TITLE
Tweak Es Lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > The version 2.1 is the last version of Breeze Lite. Since Laravel version 12 encourage programmer to use starter kit then the Laravel Breeze will be abandon and Breeze Lite too.
 > The version 2.1 requires NodeJS version with minimum version 20.19.0 or >= 22.12.0. Please see [issue #24](https://github.com/senkulabs/breeze-lite/issues/24).
 
-Unofficial Laravel Breeze for Inertia + Svelte until Laravel Breeze ship the official for Inertia + Svelte. Until then, enjoy! 🍺
+Unofficial Laravel Breeze for Inertia + Svelte. Enjoy! 🍺
 
 > Lite = Laravel + Inertia + Svelte. I like it!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ description: Unofficial Laravel Breeze for Inertia and Svelte.
 
 # Home
 
-Unofficial Laravel Breeze for Inertia + Svelte until Laravel Breeze release the official for Inertia + Svelte. Until then, enjoy! 🍺
+Unofficial Laravel Breeze for Inertia + Svelte. Enjoy! 🍺
 
 > Lite = Laravel + Inertia + Svelte. It's lite and I like it!
 

--- a/src/Console/InstallsInertiaStacks.php
+++ b/src/Console/InstallsInertiaStacks.php
@@ -47,8 +47,8 @@ trait InstallsInertiaStacks
         if ($this->option('eslint')) {
             $this->updateNodePackages(function ($packages) {
                 return [
-                    'eslint' => '^9.7.0',
-                    'eslint-plugin-svelte' => '^2.36.0',
+                    'eslint' => '^9.32.0',
+                    'eslint-plugin-svelte' => '^3.11.0',
                     'eslint-config-prettier' => '^9.1.0',
                     'prettier' => '^3.3.3',
                     'prettier-plugin-organize-imports' => '^4.0.0',
@@ -156,8 +156,9 @@ trait InstallsInertiaStacks
         copy(base_path('vendor/laravel/breeze/stubs/inertia-common/routes/web.php'), base_path('routes/web.php'));
         copy(base_path('vendor/laravel/breeze/stubs/inertia-common/routes/auth.php'), base_path('routes/auth.php'));
 
-        // Tailwind / Vite...
+        // Tailwind / Vite / Svelte...
         copy(__DIR__.'/../../stubs/inertia-svelte/vite.config.js', base_path('vite.config.js'));
+        copy(__DIR__.'/../../stubs/inertia-svelte/svelte.config.js', base_path('svelte.config.js'));
         copy(__DIR__.'/../../stubs/default/resources/css/app.css', resource_path('css/app.css'));
         $this->replaceInFile('.js', '.svelte', resource_path('css/app.css'));
 

--- a/stubs/inertia-svelte-ts/eslint.config.js
+++ b/stubs/inertia-svelte-ts/eslint.config.js
@@ -3,6 +3,7 @@ import js from '@eslint/js';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
 import ts from 'typescript-eslint';
+import svelteConfig from './svelte.config.js';
 
 export default ts.config(
 	js.configs.recommended,
@@ -19,11 +20,14 @@ export default ts.config(
 		}
 	},
 	{
-		files: ['**/*.svelte'],
+		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
 
 		languageOptions: {
 			parserOptions: {
-				parser: ts.parser
+				projectService: true,
+				extraFileExtensions: ['.svelte'],
+				parser: ts.parser,
+				svelteConfig
 			}
 		}
 	},

--- a/stubs/inertia-svelte/eslint.config.js
+++ b/stubs/inertia-svelte/eslint.config.js
@@ -2,6 +2,7 @@ import prettier from 'eslint-config-prettier';
 import js from '@eslint/js';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
+import svelteConfig from './svelte.config.js';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -17,6 +18,18 @@ export default [
 			}
 		}
 	},
+	{
+		files: ['**/*.svelte', '**/*.svelte.js'],
+		languageOptions: {
+			parserOptions: {
+				// We recommend importing and specifying svelte.config.js.
+				// By doing so, some rules in eslint-plugin-svelte will automatically read the configuration and adjust their behavior accordingly.
+				// While certain Svelte settings may be statically loaded from svelte.config.js even if you don’t specify it,
+				// explicitly specifying it ensures better compatibility and functionality.
+				svelteConfig
+			}
+		}
+  	},
 	{
 		ignores: ['bootstrap', 'public', 'vendor']
 	},

--- a/stubs/inertia-svelte/jsconfig.json
+++ b/stubs/inertia-svelte/jsconfig.json
@@ -6,6 +6,6 @@
             "ziggy-js": ["./vendor/tightenco/ziggy"]
         }
     },
-    "include": ["resources/js/**/*.js", "resources/js/**/*.svelte"],
+    "include": ["resources/js/**/*.js", "resources/js/**/*.svelte", "resources/js/**/*.svelte.js"],
     "exclude": ["node_modules", "public", "vendor"]
 }

--- a/stubs/inertia-svelte/svelte.config.js
+++ b/stubs/inertia-svelte/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
+}


### PR DESCRIPTION
I get these shit errors previously if I'm using the previous eslint for Svelte version.

```sh
/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/ApplicationLogo.svelte
  4:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/Checkbox.svelte
  7:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/DangerButton.svelte
  8:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/DropdownLink.svelte
  7:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/InputError.svelte
  6:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/InputLabel.svelte
  9:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/NavLink.svelte
  8:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/PrimaryButton.svelte
  8:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/ResponsiveNavLink.svelte
  8:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/SecondaryButton.svelte
  9:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

/Users/kresnasatya/Sandbox/inertia2-svelte5-issue/resources/js/Components/TextInput.svelte
  8:9  error  Using a rest element or a non-destructured declaration with `$props()` means that Svelte can't infer what properties to expose when creating a custom element. Consider destructuring all the props or explicitly specifying the `customElement.props` option.
https://svelte.dev/e/custom_element_props_identifier(custom_element_props_identifier)  svelte/valid-compile

✖ 11 problems (11 errors, 0 warnings)
```

Now, it's gone.